### PR TITLE
Add connected client metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,4 @@ Name|Description|Labels
  omada_controller_uptime_seconds |  Uptime of the controller. | controller_name, model, controller_version, firmware_version, mac
  omada_controller_storage_used_bytes |  Storage used on the controller. | storage_name, controller_name, model, controller_version, firmware_version, mac
  omada_controller_storage_available_bytes |  Total storage available for the controller. | storage_name, controller_name, model, controller_version, firmware_version, mac
+ omada_client_connected_total |  Total number of connected clients. | site

--- a/pkg/omada/handler.go
+++ b/pkg/omada/handler.go
@@ -108,6 +108,8 @@ func setPortMetricsByDevice(c *api.Client, device api.Device, site string) error
 
 // set prometheus metrics for clients
 func setClientMetrics(clients []api.NetworkClient, site string) {
+	omada_connected_clients_count.WithLabelValues(site).Set(float64(len(clients)))
+
 	for _, item := range clients {
 		vlanId := fmt.Sprintf("%.0f", item.VlanId)
 		port := fmt.Sprintf("%.0f", item.Port)

--- a/pkg/omada/handler.go
+++ b/pkg/omada/handler.go
@@ -108,7 +108,7 @@ func setPortMetricsByDevice(c *api.Client, device api.Device, site string) error
 
 // set prometheus metrics for clients
 func setClientMetrics(clients []api.NetworkClient, site string) {
-	omada_connected_clients_count.WithLabelValues(site).Set(float64(len(clients)))
+	omada_client_connected_total.WithLabelValues(site).Set(float64(len(clients)))
 
 	for _, item := range clients {
 		vlanId := fmt.Sprintf("%.0f", item.VlanId)

--- a/pkg/omada/metrics.go
+++ b/pkg/omada/metrics.go
@@ -95,4 +95,10 @@ var (
 		Help: "Total storage available for the controller.",
 	},
 		[]string{"storage_name", "controller_name", "model", "controller_version", "firmware_version", "mac"})
+
+	omada_connected_clients_count = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "omada_connected_clients_count",
+		Help: "Total number of connected clients.",
+	},
+		[]string{"site"})
 )

--- a/pkg/omada/metrics.go
+++ b/pkg/omada/metrics.go
@@ -96,8 +96,8 @@ var (
 	},
 		[]string{"storage_name", "controller_name", "model", "controller_version", "firmware_version", "mac"})
 
-	omada_connected_clients_count = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "omada_connected_clients_count",
+	omada_client_connected_total = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "omada_client_connected_total",
 		Help: "Total number of connected clients.",
 	},
 		[]string{"site"})


### PR DESCRIPTION
This PR adds a metric to track the currently connected client count.

I first looked at aggregating over the existing client metrics to derive this value.. but then realized it includes historical clients that may not be connected anymore!