### PR TITLE
🔧: disable collector metrics by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ GLOBAL OPTIONS:
    --site value                 Omada site to scrape metrics from. (default: "Default") [$OMADA_SITE]
    --interval value             Interval between scrapes, in seconds. (default: 5) [$OMADA_SCRAPE_INTERVAL]
    --insecure                   Whether to skip verifying the SSL certificate on the controller. (default: false) [$OMADA_INSECURE]
-   --disable-go-collector       Disable Go collector metrics. (default: false) [$OMADA_DISABLE_GO_COLLECTOR]
-   --disable-process-collector  Disable process collector metrics. (default: false) [$OMADA_DISABLE_PROCESS_COLLECTOR]
+   --disable-go-collector       Disable Go collector metrics. (default: true) [$OMADA_DISABLE_GO_COLLECTOR]
+   --disable-process-collector  Disable process collector metrics. (default: true) [$OMADA_DISABLE_PROCESS_COLLECTOR]
    --help, -h                   show help (default: false)
    --version, -v                print the version (default: false)
 ```
@@ -93,8 +93,8 @@ OMADA_SITE               | Site you'd like to get metrics from. (default: "Defau
 OMADA_PORT               | Port on which to expose the Prometheus metrics. (default: 9202)
 OMADA_INSECURE           | Whether to skip verifying the SSL certificate on the controller. (default: false)
 OMADA_SCRAPE_INTERVAL    | Interval between scrapes, in seconds. (default: 5)
-OMADA_DISABLE_GO_COLLECTOR | Disable Go collector metrics.
-OMADA_DISABLE_PROCESS_COLLECTOR | Disable process collector metrics.
+OMADA_DISABLE_GO_COLLECTOR | Disable Go collector metrics. (default: true)
+OMADA_DISABLE_PROCESS_COLLECTOR | Disable process collector metrics. (default: true)
 
 ### Helm
 ```

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -45,8 +45,8 @@ func Run() {
 		&cli.StringFlag{Destination: &site, Name: "site", Value: "Default", Usage: "Omada site to scrape metrics from.", EnvVars: []string{"OMADA_SITE"}},
 		&cli.IntFlag{Destination: &interval, Name: "interval", Value: 5, Usage: "Interval between scrapes, in seconds.", EnvVars: []string{"OMADA_SCRAPE_INTERVAL"}},
 		&cli.BoolFlag{Destination: &insecure, Name: "insecure", Value: false, Usage: "Whether to skip verifying the SSL certificate on the controller.", EnvVars: []string{"OMADA_INSECURE"}},
-		&cli.BoolFlag{Destination: &goCollectorDisabled, Name: "disable-go-collector", Value: false, Usage: "Disable Go collector metrics.", EnvVars: []string{"OMADA_DISABLE_GO_COLLECTOR"}},
-		&cli.BoolFlag{Destination: &processCollectorDisabled, Name: "disable-process-collector", Value: false, Usage: "Disable process collector metrics.", EnvVars: []string{"OMADA_DISABLE_PROCESS_COLLECTOR"}},
+		&cli.BoolFlag{Destination: &goCollectorDisabled, Name: "disable-go-collector", Value: true, Usage: "Disable Go collector metrics.", EnvVars: []string{"OMADA_DISABLE_GO_COLLECTOR"}},
+		&cli.BoolFlag{Destination: &processCollectorDisabled, Name: "disable-process-collector", Value: true, Usage: "Disable process collector metrics.", EnvVars: []string{"OMADA_DISABLE_PROCESS_COLLECTOR"}},
 	}
 	app.Commands = []*cli.Command{
 		{Name: "version", Aliases: []string{"v"}, Usage: "prints the current version.",


### PR DESCRIPTION
Disable Go/process collector metrics, they're not useful enabled by default