### PR TITLE
🐛 fix duplicate metrics being registered

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ Name|Description|Labels
  omada_device_poe_remain_watts |  The remaining amount of PoE power for the device in watts. | device, model, version, ip, mac, site, site_id, device_type
  omada_client_download_activity_bytes |  The current download activity for the client in bytes. | client, vendor, switch_port, vlan_id, ip, mac, site, site_id, ap_name, ssid, wifi_mode
  omada_client_signal_dbm |  The signal level for the wireless client in dBm. | client, vendor, ip, mac, ap_name, site, site_id, ssid, wifi_mode
- omada_port_power_watts |  The current PoE usage of the port in watts. | client, vendor, switch_port, switch_mac, switch_id, vlan_id, profile, site, site_id
- omada_port_link_status |  A boolean representing the link status of the port. | client, vendor, switch_port, switch_mac, switch_id, vlan_id, profile, site, site_id
- omada_port_link_speed_mbps |  Port link speed in mbps. This is the capability of the connection, not the active throughput. | client, vendor, switch_port, switch_mac, switch_id, vlan_id, profile, site, site_id
+ omada_port_power_watts |  The current PoE usage of the port in watts. | device, device_mac, client, vendor, switch_port, switch_mac, switch_id, vlan_id, profile, site, site_id
+ omada_port_link_status |  A boolean representing the link status of the port. | device, device_mac, client, vendor, switch_port, switch_mac, switch_id, vlan_id, profile, site, site_id
+ omada_port_link_speed_mbps |  Port link speed in mbps. This is the capability of the connection, not the active throughput. | device, device_mac, client, vendor, switch_port, switch_mac, switch_id, vlan_id, profile, site, site_id
  omada_controller_uptime_seconds |  Uptime of the controller. | controller_name, model, controller_version, firmware_version, mac
  omada_controller_storage_used_bytes |  Storage used on the controller. | storage_name, controller_name, model, controller_version, firmware_version, mac
  omada_controller_storage_available_bytes |  Total storage available for the controller. | storage_name, controller_name, model, controller_version, firmware_version, mac

--- a/pkg/collector/port.go
+++ b/pkg/collector/port.go
@@ -33,20 +33,12 @@ func (c *portCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	for _, device := range devices {
-		for _, p := range device.Ports {
-			linkSpeed := float64(0)
-			if p.PortStatus.LinkSpeed == 0 {
-				linkSpeed = 0
-			}
-			if p.PortStatus.LinkSpeed == 1 {
-				linkSpeed = 10
-			}
-			if p.PortStatus.LinkSpeed == 2 {
-				linkSpeed = 100
-			}
-			if p.PortStatus.LinkSpeed == 3 {
-				linkSpeed = 1000
-			}
+		// The Omada exporter sometimes returns duplicate ports. e.g an 8 port switch will return 16 ports with identical ports
+		// this causes issues with Prometheus as it tries to register duplicate metrics. A bit of hacky fix, but here we remove
+		// duplicate ports to prevent this error.
+		ports := removeDuplicates(device.Ports)
+		for _, p := range ports {
+			linkSpeed := getPortByLinkSpeed(p.PortStatus.LinkSpeed)
 
 			portClient, err := client.GetClientByPort(device.Mac, p.Port)
 			if err != nil {
@@ -58,43 +50,73 @@ func (c *portCollector) Collect(ch chan<- prometheus.Metric) {
 				vlanId := fmt.Sprintf("%.0f", portClient.VlanId)
 
 				ch <- prometheus.MustNewConstMetric(c.omadaPortPowerWatts, prometheus.GaugeValue, p.PortStatus.PoePower,
-					portClient.HostName, portClient.Vendor, port, p.SwitchMac, p.SwitchId, vlanId, p.ProfileName, site, client.SiteId)
+					device.Name, device.Mac, portClient.HostName, portClient.Vendor, port, p.SwitchMac, p.SwitchId, vlanId, p.ProfileName, site, client.SiteId)
 
 				ch <- prometheus.MustNewConstMetric(c.omadaPortLinkStatus, prometheus.GaugeValue, p.PortStatus.LinkStatus,
-					portClient.HostName, portClient.Vendor, port, p.SwitchMac, p.SwitchId, vlanId, p.ProfileName, site, client.SiteId)
+					device.Name, device.Mac, portClient.HostName, portClient.Vendor, port, p.SwitchMac, p.SwitchId, vlanId, p.ProfileName, site, client.SiteId)
 
 				ch <- prometheus.MustNewConstMetric(c.omadaPortLinkSpeedMbps, prometheus.GaugeValue, linkSpeed,
-					portClient.HostName, portClient.Vendor, port, p.SwitchMac, p.SwitchId, vlanId, p.ProfileName, site, client.SiteId)
+					device.Name, device.Mac, portClient.HostName, portClient.Vendor, port, p.SwitchMac, p.SwitchId, vlanId, p.ProfileName, site, client.SiteId)
 			} else {
-
 				ch <- prometheus.MustNewConstMetric(c.omadaPortPowerWatts, prometheus.GaugeValue, p.PortStatus.PoePower,
-					"", "", port, p.SwitchMac, p.SwitchId, "", p.ProfileName, site, client.SiteId)
+					device.Name, device.Mac, "", "", port, p.SwitchMac, p.SwitchId, "", p.ProfileName, site, client.SiteId)
 
 				ch <- prometheus.MustNewConstMetric(c.omadaPortLinkStatus, prometheus.GaugeValue, p.PortStatus.LinkStatus,
-					"", "", port, p.SwitchMac, p.SwitchId, "", p.ProfileName, site, client.SiteId)
+					device.Name, device.Mac, "", "", port, p.SwitchMac, p.SwitchId, "", p.ProfileName, site, client.SiteId)
 
 				ch <- prometheus.MustNewConstMetric(c.omadaPortLinkSpeedMbps, prometheus.GaugeValue, linkSpeed,
-					"", "", port, p.SwitchMac, p.SwitchId, "", p.ProfileName, site, client.SiteId)
+					device.Name, device.Mac, "", "", port, p.SwitchMac, p.SwitchId, "", p.ProfileName, site, client.SiteId)
 			}
 		}
 	}
+}
+
+func getPortByLinkSpeed(ls float64) float64 {
+	switch ls {
+	case 0:
+		return 0
+	case 1:
+		return 10
+	case 2:
+		return 100
+	case 3:
+		return 1000
+	}
+	return 0
+}
+
+func removeDuplicates(s []api.Port) []api.Port {
+	// create map to track found items
+	found := map[api.Port]bool{}
+	res := []api.Port{}
+
+	for v := range s {
+		if found[s[v]] {
+			// skip adding to new array if it exists
+			continue
+		}
+		// add to new array, mark as found
+		found[s[v]] = true
+		res = append(res, s[v])
+	}
+	return res
 }
 
 func NewPortCollector(c *api.Client) *portCollector {
 	return &portCollector{
 		omadaPortPowerWatts: prometheus.NewDesc("omada_port_power_watts",
 			"The current PoE usage of the port in watts.",
-			[]string{"client", "vendor", "switch_port", "switch_mac", "switch_id", "vlan_id", "profile", "site", "site_id"},
+			[]string{"device", "device_mac", "client", "vendor", "switch_port", "switch_mac", "switch_id", "vlan_id", "profile", "site", "site_id"},
 			nil,
 		),
 		omadaPortLinkStatus: prometheus.NewDesc("omada_port_link_status",
 			"A boolean representing the link status of the port.",
-			[]string{"client", "vendor", "switch_port", "switch_mac", "switch_id", "vlan_id", "profile", "site", "site_id"},
+			[]string{"device", "device_mac", "client", "vendor", "switch_port", "switch_mac", "switch_id", "vlan_id", "profile", "site", "site_id"},
 			nil,
 		),
 		omadaPortLinkSpeedMbps: prometheus.NewDesc("omada_port_link_speed_mbps",
 			"Port link speed in mbps. This is the capability of the connection, not the active throughput.",
-			[]string{"client", "vendor", "switch_port", "switch_mac", "switch_id", "vlan_id", "profile", "site", "site_id"},
+			[]string{"device", "device_mac", "client", "vendor", "switch_port", "switch_mac", "switch_id", "vlan_id", "profile", "site", "site_id"},
 			nil,
 		),
 		client: c,


### PR DESCRIPTION
Fixes https://github.com/charlie-haley/omada_exporter/issues/55


For some reason, the Omada API returns duplicate ports for some devices, this causes issues with registering Prometheus metrics. A simple, but hacky fix to simply remove duplicate ports before iterating.