### PR TITLE
🐛 fix duplicate switch ports

### DIFF
--- a/pkg/api/device.go
+++ b/pkg/api/device.go
@@ -45,16 +45,13 @@ func (c *Client) GetDevices() ([]Device, error) {
 	devicedata := deviceResponse{}
 	err = json.Unmarshal(body, &devicedata)
 
-	var ports []Port
 	for i, d := range devicedata.Result {
 		if d.Type == "switch" {
 			switchPorts, err := c.GetPorts(d.Mac)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get ports: %s", err)
 			}
-			ports = append(ports, switchPorts...)
-			device := &devicedata.Result[i]
-			device.Ports = ports
+			devicedata.Result[i].Ports = switchPorts
 		}
 	}
 


### PR DESCRIPTION
When iterating through devices, switch ports were being accumulated across the devices. Only the first device actually had the correct complement of ports, with subsequent devices having their own, plus the previous device’s ports.

Unclear if this is the actual problem  c48cd4d7  was trying to address, or different scenario I don’t see in my environment, so I left it in.