### PR TITLE
Add support for "download" and "upload" counters

### DIFF
--- a/pkg/api/device.go
+++ b/pkg/api/device.go
@@ -76,4 +76,6 @@ type Device struct {
 	RxRate      float64 `json:"rxRate"`
 	PoeRemain   float64 `json:"poeRemain"`
 	Ports       []Port  `json:"ports"`
+	Download    int64   `json:"download"`
+	Upload      int64   `json:"upload"`
 }

--- a/pkg/collector/device.go
+++ b/pkg/collector/device.go
@@ -14,6 +14,8 @@ type deviceCollector struct {
 	omadaDeviceTxRate         *prometheus.Desc
 	omadaDeviceRxRate         *prometheus.Desc
 	omadaDevicePoeRemainWatts *prometheus.Desc
+	omadaDeviceDownload       *prometheus.Desc
+	omadaDeviceUpload         *prometheus.Desc
 	client                    *api.Client
 }
 
@@ -26,6 +28,8 @@ func (c *deviceCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.omadaDeviceTxRate
 	ch <- c.omadaDeviceRxRate
 	ch <- c.omadaDevicePoeRemainWatts
+	ch <- c.omadaDeviceDownload
+	ch <- c.omadaDeviceUpload
 }
 
 func (c *deviceCollector) Collect(ch chan<- prometheus.Metric) {
@@ -50,6 +54,8 @@ func (c *deviceCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(c.omadaDeviceCpuPercentage, prometheus.GaugeValue, item.CpuUtil, labels...)
 		ch <- prometheus.MustNewConstMetric(c.omadaDeviceMemPercentage, prometheus.GaugeValue, item.MemUtil, labels...)
 		ch <- prometheus.MustNewConstMetric(c.omadaDeviceNeedUpgrade, prometheus.GaugeValue, needUpgrade, labels...)
+		ch <- prometheus.MustNewConstMetric(c.omadaDeviceDownload, prometheus.CounterValue, float64(item.Download), labels...)
+		ch <- prometheus.MustNewConstMetric(c.omadaDeviceUpload, prometheus.CounterValue, float64(item.Upload), labels...)
 		if item.Type == "ap" {
 			ch <- prometheus.MustNewConstMetric(c.omadaDeviceTxRate, prometheus.CounterValue, item.TxRate, labels...)
 			ch <- prometheus.MustNewConstMetric(c.omadaDeviceRxRate, prometheus.CounterValue, item.RxRate, labels...)


### PR DESCRIPTION
Download/upload absolute counters seem to exist on all devices, including switches and gateways.

Documentation reads: "The entry is the download/update traffic." My best guess is that this is a total value reported in bytes, starting since the device was last "up".