### PR TITLE
refactor/fix: api requests and headers

### DIFF
--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -18,9 +18,7 @@ func (c *Client) IsLoggedIn() (bool, error) {
 		return false, err
 	}
 
-	setHeaders(req, c.token)
-
-	res, err := c.httpClient.Do(req)
+	res, err := c.makeRequest(req)
 	if err != nil {
 		return false, err
 	}
@@ -76,8 +74,8 @@ func (c *Client) Login() error {
 		return err
 	}
 
-	setHeaders(req, "")
-	res, err := c.httpClient.Do(req)
+	req.Header.Add("Content-Type", "application/json; charset=UTF-8")
+	res, err := c.makeRequest(req)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -35,19 +35,6 @@ func (c *Client) GetClients() ([]NetworkClient, error) {
 
 // gets clients by filters in omada - currentl supports SwitchMac
 func (c *Client) getClientsWithFilters(filtersEnabled bool, mac string) ([]NetworkClient, error) {
-	loggedIn, err := c.IsLoggedIn()
-	if err != nil {
-		return nil, err
-	}
-	if !loggedIn {
-		log.Info().Msg(fmt.Sprintf("not logged in, logging in with user: %s", c.Config.Username))
-		err := c.Login()
-		if err != nil || c.token == "" {
-			log.Error().Err(err).Msg("Failed to login")
-			return nil, err
-		}
-	}
-
 	url := fmt.Sprintf("%s/%s/api/v2/sites/%s/clients", c.Config.Host, c.omadaCID, c.SiteId)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -64,8 +51,7 @@ func (c *Client) getClientsWithFilters(filtersEnabled bool, mac string) ([]Netwo
 
 	req.URL.RawQuery = q.Encode()
 
-	setHeaders(req, c.token)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.makeLoggedInRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -104,9 +90,9 @@ type NetworkClient struct {
 	SignalLevel float64 `json:"signalLevel"`
 	WifiMode    float64 `json:"wifiMode"`
 	Ssid        string  `json:"ssid"`
-	Rssi		float64 `json:"rssi"`
-	TrafficDown	float64 `json:"trafficDown"`
-	TrafficUp	float64 `json:"trafficUp"`
-	RxRate		float64 `json:"rxRate"`
-	TxRate		float64 `json:"txRate"`
+	Rssi        float64 `json:"rssi"`
+	TrafficDown float64 `json:"trafficDown"`
+	TrafficUp   float64 `json:"trafficUp"`
+	RxRate      float64 `json:"rxRate"`
+	TxRate      float64 `json:"txRate"`
 }

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -10,27 +10,13 @@ import (
 )
 
 func (c *Client) GetController() (*Controller, error) {
-	loggedIn, err := c.IsLoggedIn()
-	if err != nil {
-		return nil, err
-	}
-	if !loggedIn {
-		log.Info().Msg(fmt.Sprintf("not logged in, logging in with user: %s", c.Config.Username))
-		err := c.Login()
-		if err != nil || c.token == "" {
-			log.Error().Err(err).Msg("failed to login")
-			return nil, err
-		}
-	}
-
 	url := fmt.Sprintf("%s/%s/api/v2/maintenance/controllerStatus?", c.Config.Host, c.omadaCID)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	setHeaders(req, c.token)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.makeLoggedInRequest(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/device.go
+++ b/pkg/api/device.go
@@ -10,27 +10,13 @@ import (
 )
 
 func (c *Client) GetDevices() ([]Device, error) {
-	loggedIn, err := c.IsLoggedIn()
-	if err != nil {
-		return nil, err
-	}
-	if !loggedIn {
-		log.Info().Msg(fmt.Sprintf("not logged in, logging in with user: %s", c.Config.Username))
-		err := c.Login()
-		if err != nil || c.token == "" {
-			log.Error().Err(err).Msg("failed to login")
-			return nil, err
-		}
-	}
-
 	url := fmt.Sprintf("%s/%s/api/v2/sites/%s/devices", c.Config.Host, c.omadaCID, c.SiteId)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	setHeaders(req, c.token)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.makeLoggedInRequest(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/port.go
+++ b/pkg/api/port.go
@@ -10,27 +10,13 @@ import (
 )
 
 func (c *Client) GetPorts(switchMac string) ([]Port, error) {
-	loggedIn, err := c.IsLoggedIn()
-	if err != nil {
-		return nil, err
-	}
-	if !loggedIn {
-		log.Info().Msg(fmt.Sprintf("not logged in, logging in with user: %s", c.Config.Username))
-		err := c.Login()
-		if err != nil || c.token == "" {
-			log.Error().Err(err).Msg("failed to login")
-			return nil, err
-		}
-	}
-
 	url := fmt.Sprintf("%s/%s/api/v2/sites/%s/switches/%s/ports", c.Config.Host, c.omadaCID, c.SiteId, switchMac)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	setHeaders(req, c.token)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.makeLoggedInRequest(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -5,33 +5,18 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-
-	log "github.com/rs/zerolog/log"
 )
 
 // there's no nice way of fetching the site ID from the `Viewer` role
 // calling the user endpoint seems to return a list of sites for the user
 func (c *Client) getSiteId(name string) (*string, error) {
-	loggedIn, err := c.IsLoggedIn()
-	if err != nil {
-		return nil, err
-	}
-	if !loggedIn {
-		log.Info().Msg(fmt.Sprintf("not logged in, logging in with user: %s", c.Config.Username))
-		err := c.Login()
-		if err != nil || c.token == "" {
-			return nil, fmt.Errorf("failed to login: %s", err)
-		}
-	}
-
 	url := fmt.Sprintf("%s/%s/api/v2/users/current", c.Config.Host, c.omadaCID)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	setHeaders(req, c.token)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.makeLoggedInRequest(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Centralized login logic in `func (*Client) makeLoggedInRequest`. Also moved `setHeaders` to `func (*Client) makeRequest` and changed some headers that are added:
- Content-Type should only be set when there's a body, so moved to `func (c *Client) Login()`
- Removed Accept-Encoding, because net/http will handle gzip automatically if the header is unset. The current implementation will fail when the response has a content encoding
- Only set Csrf-Token if there's a token