### PR TITLE
fix: Omada v6.x compatibility + new features

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,40 +6,40 @@ on:
     tags:
     - 'v*'
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v1
-
-    - name: Login to Docker Hub
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+      uses: docker/setup-buildx-action@v3
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
-        username: "charlie-haley"
+        username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.19
+        go-version: '1.19'
 
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v2.8.1
+      uses: goreleaser/goreleaser-action@v6
       with:
         version: latest
         args: release --clean

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,7 +34,7 @@ dockers:
       - "ghcr.io/leicas/omada_exporter:{{ .Major }}.{{ .Minor }}-amd64"
       - "ghcr.io/leicas/omada_exporter:{{ .Major }}-amd64"
     use: buildx
-    dockerfile: Dockerfile
+    dockerfile: Dockerfile.goreleaser
     goarch: amd64
     build_flag_templates:
       - "--pull"
@@ -53,7 +53,7 @@ dockers:
       - "ghcr.io/leicas/omada_exporter:{{ .Major }}.{{ .Minor }}-arm64v8"
       - "ghcr.io/leicas/omada_exporter:{{ .Major }}-arm64v8"
     use: buildx
-    dockerfile: Dockerfile
+    dockerfile: Dockerfile.goreleaser
     goarch: arm64
     build_flag_templates:
     - "--pull"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 env:
   - GO111MODULE=on
 
@@ -19,21 +21,16 @@ builds:
       - -trimpath
     ldflags:
       - -s -w
+      - -X github.com/charlie-haley/omada_exporter/cmd.version={{ .Version }}
     binary: omada-exporter
 
 dockers:
   - image_templates:
-      - "docker.io/chhaley/omada_exporter:latest-amd64"
-      - "docker.io/chhaley/omada_exporter:{{ .Version }}-amd64"
-      - "docker.io/chhaley/omada_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
-      - "docker.io/chhaley/omada_exporter:{{ .Major }}.{{ .Minor }}-amd64"
-      - "docker.io/chhaley/omada_exporter:{{ .Major }}-amd64"
-
-      - "ghcr.io/charlie-haley/omada_exporter:latest-amd64"
-      - "ghcr.io/charlie-haley/omada_exporter:{{ .Version }}-amd64"
-      - "ghcr.io/charlie-haley/omada_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
-      - "ghcr.io/charlie-haley/omada_exporter:{{ .Major }}.{{ .Minor }}-amd64"
-      - "ghcr.io/charlie-haley/omada_exporter:{{ .Major }}-amd64"
+      - "ghcr.io/leicas/omada_exporter:latest-amd64"
+      - "ghcr.io/leicas/omada_exporter:{{ .Version }}-amd64"
+      - "ghcr.io/leicas/omada_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
+      - "ghcr.io/leicas/omada_exporter:{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/leicas/omada_exporter:{{ .Major }}-amd64"
     use: buildx
     dockerfile: Dockerfile
     goarch: amd64
@@ -48,17 +45,11 @@ dockers:
       - "--build-arg=VCS_REF={{.FullCommit}}"
       - "--platform=linux/amd64"
   - image_templates:
-      - "docker.io/chhaley/omada_exporter:latest-arm64v8"
-      - "docker.io/chhaley/omada_exporter:{{ .Version }}-arm64v8"
-      - "docker.io/chhaley/omada_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64v8"
-      - "docker.io/chhaley/omada_exporter:{{ .Major }}.{{ .Minor }}-arm64v8"
-      - "docker.io/chhaley/omada_exporter:{{ .Major }}-arm64v8"
-
-      - "ghcr.io/charlie-haley/omada_exporter:latest-arm64v8"
-      - "ghcr.io/charlie-haley/omada_exporter:{{ .Version }}-arm64v8"
-      - "ghcr.io/charlie-haley/omada_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64v8"
-      - "ghcr.io/charlie-haley/omada_exporter:{{ .Major }}.{{ .Minor }}-arm64v8"
-      - "ghcr.io/charlie-haley/omada_exporter:{{ .Major }}-arm64v8"
+      - "ghcr.io/leicas/omada_exporter:latest-arm64v8"
+      - "ghcr.io/leicas/omada_exporter:{{ .Version }}-arm64v8"
+      - "ghcr.io/leicas/omada_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64v8"
+      - "ghcr.io/leicas/omada_exporter:{{ .Major }}.{{ .Minor }}-arm64v8"
+      - "ghcr.io/leicas/omada_exporter:{{ .Major }}-arm64v8"
     use: buildx
     dockerfile: Dockerfile
     goarch: arm64
@@ -74,60 +65,33 @@ dockers:
     - "--platform=linux/arm64/v8"
 
 docker_manifests:
-## Docker Hub
-  - name_template: docker.io/chhaley/omada_exporter:latest
+  - name_template: ghcr.io/leicas/omada_exporter:latest
     image_templates:
-    - docker.io/chhaley/omada_exporter:latest-amd64
-    - docker.io/chhaley/omada_exporter:latest-arm64v8
+    - ghcr.io/leicas/omada_exporter:latest-amd64
+    - ghcr.io/leicas/omada_exporter:latest-arm64v8
 
-  - name_template: docker.io/chhaley/omada_exporter:{{ .Version }}
+  - name_template: ghcr.io/leicas/omada_exporter:{{ .Version }}
     image_templates:
-    - docker.io/chhaley/omada_exporter:{{ .Version }}-amd64
-    - docker.io/chhaley/omada_exporter:{{ .Version }}-arm64v8
+    - ghcr.io/leicas/omada_exporter:{{ .Version }}-amd64
+    - ghcr.io/leicas/omada_exporter:{{ .Version }}-arm64v8
 
-  - name_template: docker.io/chhaley/omada_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}
+  - name_template: ghcr.io/leicas/omada_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}
     image_templates:
-    - docker.io/chhaley/omada_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64
-    - docker.io/chhaley/omada_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64v8
+    - ghcr.io/leicas/omada_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64
+    - ghcr.io/leicas/omada_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64v8
 
-  - name_template: docker.io/chhaley/omada_exporter:{{ .Major }}.{{ .Minor }}
+  - name_template: ghcr.io/leicas/omada_exporter:{{ .Major }}.{{ .Minor }}
     image_templates:
-    - docker.io/chhaley/omada_exporter:{{ .Major }}.{{ .Minor }}-amd64
-    - docker.io/chhaley/omada_exporter:{{ .Major }}.{{ .Minor }}-arm64v8
+    - ghcr.io/leicas/omada_exporter:{{ .Major }}.{{ .Minor }}-amd64
+    - ghcr.io/leicas/omada_exporter:{{ .Major }}.{{ .Minor }}-arm64v8
 
-  - name_template: docker.io/chhaley/omada_exporter:{{ .Major }}
+  - name_template: ghcr.io/leicas/omada_exporter:{{ .Major }}
     image_templates:
-    - docker.io/chhaley/omada_exporter:{{ .Major }}-amd64
-    - docker.io/chhaley/omada_exporter:{{ .Major }}-arm64v8
-
-## GHCR
-  - name_template: ghcr.io/charlie-haley/omada_exporter:latest
-    image_templates:
-    - ghcr.io/charlie-haley/omada_exporter:latest-amd64
-    - ghcr.io/charlie-haley/omada_exporter:latest-arm64v8
-
-  - name_template: ghcr.io/charlie-haley/omada_exporter:{{ .Version }}
-    image_templates:
-    - ghcr.io/charlie-haley/omada_exporter:{{ .Version }}-amd64
-    - ghcr.io/charlie-haley/omada_exporter:{{ .Version }}-arm64v8
-
-  - name_template: ghcr.io/charlie-haley/omada_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}
-    image_templates:
-    - ghcr.io/charlie-haley/omada_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64
-    - ghcr.io/charlie-haley/omada_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64v8
-
-  - name_template: ghcr.io/charlie-haley/omada_exporter:{{ .Major }}.{{ .Minor }}
-    image_templates:
-    - ghcr.io/charlie-haley/omada_exporter:{{ .Major }}.{{ .Minor }}-amd64
-    - ghcr.io/charlie-haley/omada_exporter:{{ .Major }}.{{ .Minor }}-arm64v8
-
-  - name_template: ghcr.io/charlie-haley/omada_exporter:{{ .Major }}
-    image_templates:
-    - ghcr.io/charlie-haley/omada_exporter:{{ .Major }}-amd64
-    - ghcr.io/charlie-haley/omada_exporter:{{ .Major }}-arm64v8
+    - ghcr.io/leicas/omada_exporter:{{ .Major }}-amd64
+    - ghcr.io/leicas/omada_exporter:{{ .Major }}-arm64v8
 
 release:
   prerelease: auto
 
 archives:
-  - format: binary
+  - formats: [ binary ]

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,8 +3,10 @@ version: 2
 env:
   - GO111MODULE=on
 
-gomod:
-  proxy: true
+# NOTE: gomod.proxy is intentionally disabled. This is a fork whose go.mod
+# module path is still github.com/charlie-haley/omada_exporter, so proxying
+# would try to fetch the tag from upstream (which doesn't have it) and fail
+# with "unknown revision". Build from the local checkout instead.
 
 builds:
   - env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
-FROM golang:alpine3.14
+FROM golang:1.19-alpine AS builder
 
-COPY omada-exporter /usr/bin/omada-exporter
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o omada-exporter .
 
+FROM alpine:3.18
+COPY --from=builder /app/omada-exporter /usr/bin/omada-exporter
 CMD ["/usr/bin/omada-exporter"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,7 @@
+# Dockerfile used by GoReleaser. GoReleaser cross-compiles the binary itself
+# and places it (named "omada-exporter") in the build context, so unlike the
+# plain ./Dockerfile this image only copies that prebuilt binary in.
+FROM alpine:3.18
+RUN apk add --no-cache ca-certificates
+COPY omada-exporter /usr/bin/omada-exporter
+ENTRYPOINT ["/usr/bin/omada-exporter"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # omada_exporter
-![docker-publish](https://github.com/charlie-haley/omada_exporter/actions/workflows/docker-publish.yml/badge.svg)
+![docker-publish](https://github.com/Leicas/omada_exporter/actions/workflows/docker-publish.yml/badge.svg)
 <p align="center" style="text-align: center">
     <img src="./docs/images/logo-dark-mode.svg#gh-dark-mode-only" width="70%"><br/>
     <img src="./docs/images/logo-light-mode.svg#gh-light-mode-only" width="70%"><br/>
@@ -27,10 +27,10 @@ docker run -d \
     -e OMADA_USER='exporter' \
     -e OMADA_PASS='mypassword' \
     -e OMADA_SITE='Default' \
-    chhaley/omada_exporter
+    ghcr.io/leicas/omada_exporter
 ```
 
-__There's also a GHCR mirror available if you'd prefer to not use Docker Hub. `ghcr.io/charlie-haley/omada_exporter`__
+> This is a fork of [charlie-haley/omada_exporter](https://github.com/charlie-haley/omada_exporter) with Omada v6.x compatibility fixes. Images are published to `ghcr.io/leicas/omada_exporter`.
 
 ### ☸️ Helm
 ```bash

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -93,12 +93,7 @@ func run(c *cli.Context) error {
 		return err
 	}
 
-	// register omada collectors on the default registry
-	for _, c := range collectors(client) {
-		prometheus.MustRegister(c)
-	}
-
-	// create per-collector registries for dedicated endpoints
+	// create collectors once, register on both default and per-collector registries
 	collectorMap := map[string]prometheus.Collector{
 		"client":     collector.NewClientCollector(client),
 		"controller": collector.NewControllerCollector(client),
@@ -107,6 +102,7 @@ func run(c *cli.Context) error {
 		"site":       collector.NewSiteCollector(client),
 	}
 	for name, c := range collectorMap {
+		prometheus.MustRegister(c)
 		reg := prometheus.NewRegistry()
 		reg.MustRegister(c)
 		http.Handle(fmt.Sprintf("/metrics/%s", name), promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))

--- a/cmd/exporter.go
+++ b/cmd/exporter.go
@@ -93,9 +93,23 @@ func run(c *cli.Context) error {
 		return err
 	}
 
-	// register omada collectors
+	// register omada collectors on the default registry
 	for _, c := range collectors(client) {
 		prometheus.MustRegister(c)
+	}
+
+	// create per-collector registries for dedicated endpoints
+	collectorMap := map[string]prometheus.Collector{
+		"client":     collector.NewClientCollector(client),
+		"controller": collector.NewControllerCollector(client),
+		"device":     collector.NewDeviceCollector(client),
+		"port":       collector.NewPortCollector(client),
+		"site":       collector.NewSiteCollector(client),
+	}
+	for name, c := range collectorMap {
+		reg := prometheus.NewRegistry()
+		reg.MustRegister(c)
+		http.Handle(fmt.Sprintf("/metrics/%s", name), promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
 	}
 
 	log.Info().Msg(fmt.Sprintf("listening on :%s", conf.Port))
@@ -107,7 +121,12 @@ func run(c *cli.Context) error {
     	<body>
 			<h1>omada_exporter</h1>
 			<p>
-				<a href="/metrics">Metrics</a>
+				<a href="/metrics">All Metrics</a><br>
+				<a href="/metrics/client">Client Metrics</a><br>
+				<a href="/metrics/controller">Controller Metrics</a><br>
+				<a href="/metrics/device">Device Metrics</a><br>
+				<a href="/metrics/port">Port Metrics</a><br>
+				<a href="/metrics/site">Site Metrics</a>
 			</p>
     	</body>
     </html>`))
@@ -160,5 +179,6 @@ func collectors(client *api.Client) []prometheus.Collector {
 		collector.NewControllerCollector(client),
 		collector.NewDeviceCollector(client),
 		collector.NewPortCollector(client),
+		collector.NewSiteCollector(client),
 	}
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"time"
@@ -126,8 +128,26 @@ func (c *Client) makeRequest(req *http.Request) (*http.Response, error) {
 // makeLoggedInRequest ensures we are logged in before making the request.
 // Instead of pre-checking login status on every call, it logs in once on first
 // use and only re-authenticates when a request returns an auth error.
+//
+// Omada session cookies and CSRF tokens expire after a period of inactivity.
+// When that happens the controller answers with HTTP 200 but an auth errorCode
+// in the JSON body, so we inspect the payload (not the status code), re-login
+// once, and replay the request. Without this the exporter would keep sending an
+// expired token forever and silently stop producing metrics until restarted.
 func (c *Client) makeLoggedInRequest(req *http.Request) (*http.Response, error) {
-	// Login once if we don't have a token yet
+	// Buffer the request body up front so the request can be replayed after a
+	// re-login (http.Request bodies are single-use once sent).
+	var bodyBytes []byte
+	if req.Body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(req.Body)
+		req.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Login once if we don't have a token yet.
 	if c.token == "" {
 		log.Info().Msg(fmt.Sprintf("not logged in, logging in with user: %s", c.Config.Username))
 		if err := c.Login(); err != nil {
@@ -135,5 +155,53 @@ func (c *Client) makeLoggedInRequest(req *http.Request) (*http.Response, error) 
 		}
 	}
 
-	return c.makeRequest(req)
+	resp, body, authErr, err := c.doDetectingAuth(req, bodyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Session expired or token rejected: re-authenticate once and replay.
+	if authErr {
+		log.Info().Msg("session expired or token rejected, re-authenticating")
+		if err := c.Login(); err != nil {
+			return nil, fmt.Errorf("re-login failed: %w", err)
+		}
+		resp, body, _, err = c.doDetectingAuth(req, bodyBytes)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Restore the consumed body so callers can read the response normally.
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	return resp, nil
+}
+
+// doDetectingAuth sends req (restoring its body from bodyBytes first), reads the
+// full response body, and reports whether the controller returned an auth error
+// code. The response body is consumed and returned separately so the caller can
+// decide whether to retry before handing it back.
+func (c *Client) doDetectingAuth(req *http.Request, bodyBytes []byte) (*http.Response, []byte, bool, error) {
+	if bodyBytes != nil {
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		req.ContentLength = int64(len(bodyBytes))
+	}
+
+	resp, err := c.makeRequest(req)
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	var probe struct {
+		ErrorCode int `json:"errorCode"`
+	}
+	authErr := json.Unmarshal(body, &probe) == nil && isAuthError(probe.ErrorCode)
+
+	return resp, body, authErr, nil
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -110,29 +110,28 @@ func Configure(c *config.Config) (*Client, error) {
 }
 
 func (c *Client) makeRequest(req *http.Request) (*http.Response, error) {
-	req.Header.Add("Accept", "application/json")
-	req.Header.Add("X-Requested-With", "XMLHttpRequest")
-	req.Header.Add("User-Agent", "omada_exporter")
-	req.Header.Add("Connection", "keep-alive")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	req.Header.Set("User-Agent", "omada_exporter")
+	req.Header.Set("Connection", "keep-alive")
+	req.Header.Set("Omada-Request-Source", "web-local")
 
 	if c.token != "" {
-		req.Header.Add("Csrf-Token", c.token)
+		req.Header.Set("Csrf-Token", c.token)
 	}
 
 	return c.httpClient.Do(req)
 }
 
+// makeLoggedInRequest ensures we are logged in before making the request.
+// Instead of pre-checking login status on every call, it logs in once on first
+// use and only re-authenticates when a request returns an auth error.
 func (c *Client) makeLoggedInRequest(req *http.Request) (*http.Response, error) {
-	loggedIn, err := c.IsLoggedIn()
-	if err != nil {
-		return nil, err
-	}
-	if !loggedIn {
+	// Login once if we don't have a token yet
+	if c.token == "" {
 		log.Info().Msg(fmt.Sprintf("not logged in, logging in with user: %s", c.Config.Username))
-		err := c.Login()
-		if err != nil || c.token == "" {
-			log.Error().Err(err).Msg("failed to login")
-			return nil, err
+		if err := c.Login(); err != nil {
+			return nil, fmt.Errorf("login failed: %w", err)
 		}
 	}
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/cookiejar"
@@ -10,6 +11,51 @@ import (
 	"github.com/charlie-haley/omada_exporter/pkg/config"
 	log "github.com/rs/zerolog/log"
 )
+
+// apiResponse is a generic Omada API response with the result as raw JSON.
+type apiResponse struct {
+	ErrorCode int             `json:"errorCode"`
+	Msg       string          `json:"msg"`
+	Result    json.RawMessage `json:"result"`
+}
+
+// checkResponse parses an API response body, checks for API-level errors,
+// and returns the raw result payload.
+func checkResponse(body []byte) (json.RawMessage, error) {
+	var resp apiResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse API response: %w", err)
+	}
+	if resp.ErrorCode != 0 {
+		return nil, fmt.Errorf("API error %d: %s", resp.ErrorCode, resp.Msg)
+	}
+	return resp.Result, nil
+}
+
+// parseListResult unmarshals a list result from an API response body.
+// It handles both direct array format ({"result": [...]}) and the paginated
+// format used by newer Omada controllers ({"result": {"data": [...]}}).
+func parseListResult[T any](body []byte) ([]T, error) {
+	raw, err := checkResponse(body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Try paginated format first: {"data": [...], "totalRows": N, ...}
+	var paginated struct {
+		Data []T `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &paginated); err == nil && paginated.Data != nil {
+		return paginated.Data, nil
+	}
+
+	// Fallback to direct array format: [...]
+	var direct []T
+	if err := json.Unmarshal(raw, &direct); err != nil {
+		return nil, fmt.Errorf("failed to parse list result: %w", err)
+	}
+	return direct, nil
+}
 
 type Client struct {
 	Config     *config.Config

--- a/pkg/api/auth.go
+++ b/pkg/api/auth.go
@@ -8,6 +8,21 @@ import (
 	"net/http"
 )
 
+// isAuthError returns true if the error code indicates an authentication
+// or session problem that should trigger a re-login rather than a fatal error.
+func isAuthError(code int) bool {
+	switch code {
+	case -1200, // not authenticated (classic)
+		-1201,  // token expired
+		-30109, // invalid token
+		-40011, // token mismatch
+		-40012, // CSRF token mismatch
+		-1:     // generic error (often auth-related on newer firmware)
+		return true
+	}
+	return false
+}
+
 func (c *Client) IsLoggedIn() (bool, error) {
 	loginstatus := loginStatus{}
 
@@ -29,14 +44,20 @@ func (c *Client) IsLoggedIn() (bool, error) {
 	}
 
 	err = json.Unmarshal(body, &loginstatus)
-	if loginstatus.ErrorCode == -1200 {
+	if err != nil {
+		return false, err
+	}
+
+	// Treat any authentication-related error code as "not logged in"
+	// so that the caller can re-attempt login.
+	if isAuthError(loginstatus.ErrorCode) {
 		return false, nil
 	}
 	if loginstatus.ErrorCode != 0 {
-		return false, fmt.Errorf("invalid error code returned from API. Response Body: %s", string(body))
+		return false, fmt.Errorf("invalid error code %d returned from loginStatus API. Response Body: %s", loginstatus.ErrorCode, string(body))
 	}
 
-	return loginstatus.Result.Login, err
+	return loginstatus.Result.Login, nil
 }
 
 // one of the "quirks" of the omada API - it requires a CID to be part of the path
@@ -74,8 +95,6 @@ func (c *Client) getCid() (string, error) {
 }
 
 func (c *Client) Login() error {
-	logindata := loginResponse{}
-
 	url := fmt.Sprintf("%s/%s/api/v2/login", c.Config.Host, c.omadaCID)
 	jsonStr := []byte(fmt.Sprintf(`{"username":"%s","password":"%s"}`, c.Config.Username, c.Config.Password))
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
@@ -95,6 +114,16 @@ func (c *Client) Login() error {
 		return err
 	}
 
+	// Check for API-level errors first
+	var apiResp struct {
+		ErrorCode int    `json:"errorCode"`
+		Msg       string `json:"msg"`
+	}
+	if err := json.Unmarshal(body, &apiResp); err == nil && apiResp.ErrorCode != 0 {
+		return fmt.Errorf("login failed with error %d: %s", apiResp.ErrorCode, apiResp.Msg)
+	}
+
+	logindata := loginResponse{}
 	err = json.Unmarshal(body, &logindata)
 	if err != nil {
 		return err

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	log "github.com/rs/zerolog/log"
 )
@@ -33,8 +34,38 @@ func (c *Client) GetClients() ([]NetworkClient, error) {
 	return client, nil
 }
 
-// gets clients by filters in omada - currentl supports SwitchMac
+// getClientsWithFilters fetches active clients. It tries the standard clients
+// endpoint first, and falls back to the insight/clients endpoint for Omada
+// controller v6.x where the standard endpoint may not be available for Viewer roles.
 func (c *Client) getClientsWithFilters(filtersEnabled bool, mac string) ([]NetworkClient, error) {
+	clients, err := c.getClientsStandard(filtersEnabled, mac)
+	if err == nil {
+		return clients, nil
+	}
+	log.Debug().Err(err).Msg("Standard clients endpoint failed, trying insight endpoint")
+
+	// Fallback: use insight/clients endpoint (works on v6.x with Viewer role)
+	clients, insightErr := c.getClientsFromInsight()
+	if insightErr != nil {
+		// Return the original error as it's more informative
+		return nil, fmt.Errorf("clients endpoint failed: %w (insight fallback also failed: %v)", err, insightErr)
+	}
+
+	// If using insight with switchMac filter, filter client-side
+	if filtersEnabled && mac != "" {
+		var filtered []NetworkClient
+		for _, cl := range clients {
+			if cl.SwitchMac == mac {
+				filtered = append(filtered, cl)
+			}
+		}
+		return filtered, nil
+	}
+
+	return clients, nil
+}
+
+func (c *Client) getClientsStandard(filtersEnabled bool, mac string) ([]NetworkClient, error) {
 	url := fmt.Sprintf("%s/%s/api/v2/sites/%s/clients", c.Config.Host, c.omadaCID, c.SiteId)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -46,7 +77,7 @@ func (c *Client) getClientsWithFilters(filtersEnabled bool, mac string) ([]Netwo
 	q.Add("currentPageSize", "10000")
 	q.Add("filters.active", "true")
 	if filtersEnabled {
-		q.Add("filters.switchMac=", mac)
+		q.Add("filters.switchMac", mac)
 	}
 
 	req.URL.RawQuery = q.Encode()
@@ -63,17 +94,85 @@ func (c *Client) getClientsWithFilters(filtersEnabled bool, mac string) ([]Netwo
 	}
 	log.Debug().Bytes("data", body).Msg("Received data from clients endpoint")
 
-	clientdata := clientResponse{}
-	err = json.Unmarshal(body, &clientdata)
+	clients, err := parseListResult[NetworkClient](body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse clients: %w", err)
+	}
 
-	return clientdata.Result.Data, err
+	return clients, nil
 }
 
-type clientResponse struct {
-	Result data `json:"result"`
-}
-type data struct {
-	Data []NetworkClient `json:"data"`
+// getClientsFromInsight fetches clients from the insight endpoint and filters
+// for recently active ones. This endpoint is available to Viewer roles on v6.x
+// controllers where the standard clients endpoint returns "General error."
+func (c *Client) getClientsFromInsight() ([]NetworkClient, error) {
+	url := fmt.Sprintf("%s/%s/api/v2/sites/%s/insight/clients", c.Config.Host, c.omadaCID, c.SiteId)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	q := req.URL.Query()
+	q.Add("currentPage", "1")
+	q.Add("currentPageSize", "10000")
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := c.makeLoggedInRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	log.Debug().Bytes("data", body).Msg("Received data from insight/clients endpoint")
+
+	raw, err := checkResponse(body)
+	if err != nil {
+		return nil, err
+	}
+
+	type insightClient struct {
+		Name     string  `json:"name"`
+		Mac      string  `json:"mac"`
+		Wireless bool    `json:"wireless"`
+		Download float64 `json:"download"`
+		Upload   float64 `json:"upload"`
+		LastSeen int64   `json:"lastSeen"`
+		VlanId   float64 `json:"vid"`
+	}
+
+	// Parse paginated result
+	var paginated struct {
+		Data []insightClient `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &paginated); err != nil {
+		return nil, fmt.Errorf("failed to parse insight clients: %w", err)
+	}
+
+	// Filter for active clients (seen in the last 10 minutes)
+	cutoff := time.Now().Add(-10 * time.Minute).UnixMilli()
+	var clients []NetworkClient
+	for _, ic := range paginated.Data {
+		if ic.LastSeen < cutoff {
+			continue
+		}
+		clients = append(clients, NetworkClient{
+			Name:        ic.Name,
+			Mac:         ic.Mac,
+			Wireless:    ic.Wireless,
+			TrafficDown: ic.Download,
+			TrafficUp:   ic.Upload,
+			VlanId:      ic.VlanId,
+		})
+	}
+
+	log.Info().Int("active", len(clients)).Int("total", len(paginated.Data)).
+		Msg("Using insight/clients fallback (some wireless metrics unavailable)")
+
+	return clients, nil
 }
 type NetworkClient struct {
 	Name        string  `json:"name"`

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -34,50 +35,33 @@ func (c *Client) GetClients() ([]NetworkClient, error) {
 	return client, nil
 }
 
-// getClientsWithFilters fetches active clients. It tries the standard clients
-// endpoint first, and falls back to a split strategy for Omada v6.x where the
-// Viewer role can only query wireless clients via the standard endpoint.
+// getClientsWithFilters fetches active clients. It tries the OpenAPI v2 endpoint
+// first (POST with JSON body, used by the web UI), then falls back to the legacy
+// api/v2 GET endpoint, and finally to the insight endpoint.
 func (c *Client) getClientsWithFilters(filtersEnabled bool, mac string) ([]NetworkClient, error) {
-	// Try the standard endpoint with no wireless filter (works on older controllers)
-	clients, err := c.getClientsStandard(filtersEnabled, mac, "")
+	// Try OpenAPI v2 endpoint (works for all clients on v6.x, same as web UI)
+	clients, err := c.getClientsOpenAPI(filtersEnabled, mac)
 	if err == nil {
 		return clients, nil
 	}
-	log.Debug().Err(err).Msg("Standard clients endpoint failed, trying wireless+wired split")
+	log.Debug().Err(err).Msg("OpenAPI clients endpoint failed, trying legacy endpoint")
 
-	// v6.x Viewer role workaround: wireless filter works, wired doesn't.
-	// Fetch wireless clients via standard endpoint (full signal/RSSI/rate data),
-	// then fetch wired clients from the insight fallback.
-	var allClients []NetworkClient
+	// Fallback: try legacy api/v2 GET endpoint (works on older controllers)
+	clients, err = c.getClientsLegacy(filtersEnabled, mac)
+	if err == nil {
+		return clients, nil
+	}
+	log.Debug().Err(err).Msg("Legacy clients endpoint failed, trying insight fallback")
 
-	wireless, wirelessErr := c.getClientsStandard(filtersEnabled, mac, "true")
-	if wirelessErr != nil {
-		log.Debug().Err(wirelessErr).Msg("Wireless clients endpoint also failed, falling back to insight for all")
-		// Full fallback to insight for everything
-		allClients, err = c.getClientsFromInsight()
-		if err != nil {
-			return nil, fmt.Errorf("all client endpoints failed: standard (%v), insight (%v)", wirelessErr, err)
-		}
-	} else {
-		allClients = append(allClients, wireless...)
-		log.Info().Int("wireless", len(wireless)).Msg("Fetched wireless clients via standard endpoint")
+	// Final fallback: insight endpoint (limited data but always works)
+	clients, insightErr := c.getClientsFromInsight()
+	if insightErr != nil {
+		return nil, fmt.Errorf("all client endpoints failed: openapi, legacy, insight (%v)", insightErr)
 	}
 
-	// Fetch wired clients from insight fallback
-	wired, wiredErr := c.getWiredClientsFromInsight()
-	if wiredErr != nil {
-		log.Debug().Err(wiredErr).Msg("Failed to get wired clients from insight")
-	} else if wirelessErr == nil {
-		// Only add wired if we got wireless from the standard endpoint
-		// (otherwise getClientsFromInsight above already included both)
-		allClients = append(allClients, wired...)
-		log.Info().Int("wired", len(wired)).Msg("Fetched wired clients via insight fallback")
-	}
-
-	// If using switchMac filter, filter client-side
 	if filtersEnabled && mac != "" {
 		var filtered []NetworkClient
-		for _, cl := range allClients {
+		for _, cl := range clients {
 			if cl.SwitchMac == mac {
 				filtered = append(filtered, cl)
 			}
@@ -85,10 +69,63 @@ func (c *Client) getClientsWithFilters(filtersEnabled bool, mac string) ([]Netwo
 		return filtered, nil
 	}
 
-	return allClients, nil
+	return clients, nil
 }
 
-func (c *Client) getClientsStandard(filtersEnabled bool, mac string, wirelessFilter string) ([]NetworkClient, error) {
+// getClientsOpenAPI fetches clients via the OpenAPI v2 POST endpoint.
+// This is the same endpoint the Omada web UI uses and returns full data
+// for both wired and wireless clients, even with Viewer role on v6.x.
+func (c *Client) getClientsOpenAPI(filtersEnabled bool, mac string) ([]NetworkClient, error) {
+	url := fmt.Sprintf("%s/openapi/v2/%s/sites/%s/clients", c.Config.Host, c.omadaCID, c.SiteId)
+
+	filters := map[string]interface{}{"active": true}
+	if filtersEnabled && mac != "" {
+		filters["switchMac"] = mac
+	}
+
+	reqBody := map[string]interface{}{
+		"filters":  filters,
+		"page":     1,
+		"pageSize": 1000,
+		"scope":    1,
+	}
+
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json;charset=utf-8")
+	req.Header.Set("Omada-Request-Source", "web-local")
+
+	resp, err := c.makeLoggedInRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	log.Debug().Bytes("data", body).Msg("Received data from OpenAPI clients endpoint")
+
+	clients, err := parseListResult[NetworkClient](body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse OpenAPI clients: %w", err)
+	}
+
+	log.Info().Int("clients", len(clients)).Msg("Fetched clients via OpenAPI v2 endpoint")
+	return clients, nil
+}
+
+// getClientsLegacy fetches clients via the legacy api/v2 GET endpoint.
+// This works on older Omada controllers but may fail on v6.x for Viewer role.
+func (c *Client) getClientsLegacy(filtersEnabled bool, mac string) ([]NetworkClient, error) {
 	url := fmt.Sprintf("%s/%s/api/v2/sites/%s/clients", c.Config.Host, c.omadaCID, c.SiteId)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -99,9 +136,6 @@ func (c *Client) getClientsStandard(filtersEnabled bool, mac string, wirelessFil
 	q.Add("currentPage", "1")
 	q.Add("currentPageSize", "10000")
 	q.Add("filters.active", "true")
-	if wirelessFilter != "" {
-		q.Add("filters.wireless", wirelessFilter)
-	}
 	if filtersEnabled {
 		q.Add("filters.switchMac", mac)
 	}
@@ -118,11 +152,11 @@ func (c *Client) getClientsStandard(filtersEnabled bool, mac string, wirelessFil
 	if err != nil {
 		return nil, err
 	}
-	log.Debug().Bytes("data", body).Msg("Received data from clients endpoint")
+	log.Debug().Bytes("data", body).Msg("Received data from legacy clients endpoint")
 
 	clients, err := parseListResult[NetworkClient](body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse clients: %w", err)
+		return nil, fmt.Errorf("failed to parse legacy clients: %w", err)
 	}
 
 	return clients, nil

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -35,26 +35,49 @@ func (c *Client) GetClients() ([]NetworkClient, error) {
 }
 
 // getClientsWithFilters fetches active clients. It tries the standard clients
-// endpoint first, and falls back to the insight/clients endpoint for Omada
-// controller v6.x where the standard endpoint may not be available for Viewer roles.
+// endpoint first, and falls back to a split strategy for Omada v6.x where the
+// Viewer role can only query wireless clients via the standard endpoint.
 func (c *Client) getClientsWithFilters(filtersEnabled bool, mac string) ([]NetworkClient, error) {
-	clients, err := c.getClientsStandard(filtersEnabled, mac)
+	// Try the standard endpoint with no wireless filter (works on older controllers)
+	clients, err := c.getClientsStandard(filtersEnabled, mac, "")
 	if err == nil {
 		return clients, nil
 	}
-	log.Debug().Err(err).Msg("Standard clients endpoint failed, trying insight endpoint")
+	log.Debug().Err(err).Msg("Standard clients endpoint failed, trying wireless+wired split")
 
-	// Fallback: use insight/clients endpoint (works on v6.x with Viewer role)
-	clients, insightErr := c.getClientsFromInsight()
-	if insightErr != nil {
-		// Return the original error as it's more informative
-		return nil, fmt.Errorf("clients endpoint failed: %w (insight fallback also failed: %v)", err, insightErr)
+	// v6.x Viewer role workaround: wireless filter works, wired doesn't.
+	// Fetch wireless clients via standard endpoint (full signal/RSSI/rate data),
+	// then fetch wired clients from the insight fallback.
+	var allClients []NetworkClient
+
+	wireless, wirelessErr := c.getClientsStandard(filtersEnabled, mac, "true")
+	if wirelessErr != nil {
+		log.Debug().Err(wirelessErr).Msg("Wireless clients endpoint also failed, falling back to insight for all")
+		// Full fallback to insight for everything
+		allClients, err = c.getClientsFromInsight()
+		if err != nil {
+			return nil, fmt.Errorf("all client endpoints failed: standard (%v), insight (%v)", wirelessErr, err)
+		}
+	} else {
+		allClients = append(allClients, wireless...)
+		log.Info().Int("wireless", len(wireless)).Msg("Fetched wireless clients via standard endpoint")
 	}
 
-	// If using insight with switchMac filter, filter client-side
+	// Fetch wired clients from insight fallback
+	wired, wiredErr := c.getWiredClientsFromInsight()
+	if wiredErr != nil {
+		log.Debug().Err(wiredErr).Msg("Failed to get wired clients from insight")
+	} else if wirelessErr == nil {
+		// Only add wired if we got wireless from the standard endpoint
+		// (otherwise getClientsFromInsight above already included both)
+		allClients = append(allClients, wired...)
+		log.Info().Int("wired", len(wired)).Msg("Fetched wired clients via insight fallback")
+	}
+
+	// If using switchMac filter, filter client-side
 	if filtersEnabled && mac != "" {
 		var filtered []NetworkClient
-		for _, cl := range clients {
+		for _, cl := range allClients {
 			if cl.SwitchMac == mac {
 				filtered = append(filtered, cl)
 			}
@@ -62,10 +85,10 @@ func (c *Client) getClientsWithFilters(filtersEnabled bool, mac string) ([]Netwo
 		return filtered, nil
 	}
 
-	return clients, nil
+	return allClients, nil
 }
 
-func (c *Client) getClientsStandard(filtersEnabled bool, mac string) ([]NetworkClient, error) {
+func (c *Client) getClientsStandard(filtersEnabled bool, mac string, wirelessFilter string) ([]NetworkClient, error) {
 	url := fmt.Sprintf("%s/%s/api/v2/sites/%s/clients", c.Config.Host, c.omadaCID, c.SiteId)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -76,6 +99,9 @@ func (c *Client) getClientsStandard(filtersEnabled bool, mac string) ([]NetworkC
 	q.Add("currentPage", "1")
 	q.Add("currentPageSize", "10000")
 	q.Add("filters.active", "true")
+	if wirelessFilter != "" {
+		q.Add("filters.wireless", wirelessFilter)
+	}
 	if filtersEnabled {
 		q.Add("filters.switchMac", mac)
 	}
@@ -170,10 +196,26 @@ func (c *Client) getClientsFromInsight() ([]NetworkClient, error) {
 	}
 
 	log.Info().Int("active", len(clients)).Int("total", len(paginated.Data)).
-		Msg("Using insight/clients fallback (some wireless metrics unavailable)")
+		Msg("Using insight/clients fallback (some metrics unavailable)")
 
 	return clients, nil
 }
+
+// getWiredClientsFromInsight fetches only wired clients from the insight endpoint.
+func (c *Client) getWiredClientsFromInsight() ([]NetworkClient, error) {
+	allClients, err := c.getClientsFromInsight()
+	if err != nil {
+		return nil, err
+	}
+	var wired []NetworkClient
+	for _, cl := range allClients {
+		if !cl.Wireless {
+			wired = append(wired, cl)
+		}
+	}
+	return wired, nil
+}
+
 type NetworkClient struct {
 	Name        string  `json:"name"`
 	HostName    string  `json:"hostName"`

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -201,19 +201,75 @@ func (c *Client) getClientsFromInsight() ([]NetworkClient, error) {
 	return clients, nil
 }
 
-// getWiredClientsFromInsight fetches only wired clients from the insight endpoint.
+// getWiredClientsDetailed fetches wired client MACs from insight, then gets
+// full details for each via /clients/{mac} (which works for Viewer role on v6.x).
 func (c *Client) getWiredClientsFromInsight() ([]NetworkClient, error) {
-	allClients, err := c.getClientsFromInsight()
+	insightClients, err := c.getClientsFromInsight()
 	if err != nil {
 		return nil, err
 	}
-	var wired []NetworkClient
-	for _, cl := range allClients {
+
+	var wiredMacs []string
+	for _, cl := range insightClients {
 		if !cl.Wireless {
-			wired = append(wired, cl)
+			wiredMacs = append(wiredMacs, cl.Mac)
 		}
 	}
+
+	if len(wiredMacs) == 0 {
+		return nil, nil
+	}
+
+	// Fetch full details for each wired client via /clients/{mac}
+	var wired []NetworkClient
+	for _, mac := range wiredMacs {
+		client, err := c.getClientByMac(mac)
+		if err != nil {
+			log.Debug().Err(err).Str("mac", mac).Msg("Failed to fetch wired client detail")
+			continue
+		}
+		if client != nil {
+			wired = append(wired, *client)
+		}
+	}
+
+	log.Info().Int("wired", len(wired)).Int("macs", len(wiredMacs)).
+		Msg("Fetched wired client details via per-client endpoint")
+
 	return wired, nil
+}
+
+// getClientByMac fetches full details for a single client by MAC address.
+// This endpoint works for Viewer role on v6.x even when the list endpoint doesn't.
+func (c *Client) getClientByMac(mac string) (*NetworkClient, error) {
+	url := fmt.Sprintf("%s/%s/api/v2/sites/%s/clients/%s", c.Config.Host, c.omadaCID, c.SiteId, mac)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.makeLoggedInRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := checkResponse(body)
+	if err != nil {
+		return nil, err
+	}
+
+	var client NetworkClient
+	if err := json.Unmarshal(raw, &client); err != nil {
+		return nil, fmt.Errorf("failed to parse client %s: %w", mac, err)
+	}
+
+	return &client, nil
 }
 
 type NetworkClient struct {

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -11,43 +11,19 @@ import (
 	log "github.com/rs/zerolog/log"
 )
 
-// gets clients by switch mac address
-func (c *Client) GetClientByPort(switchMac string, port float64) (*NetworkClient, error) {
-	clients, err := c.getClientsWithFilters(true, switchMac)
-	if err != nil {
-		return nil, err
-	}
-	for _, client := range clients {
-		if client.Port == port {
-			return &client, nil
-		}
-	}
-	return nil, nil
-}
-
-// gets all clients
+// GetClients fetches all active clients. It tries the OpenAPI v2 endpoint first
+// (POST with JSON body, same as the web UI), then falls back to the legacy api/v2
+// GET endpoint, and finally to the insight endpoint.
 func (c *Client) GetClients() ([]NetworkClient, error) {
-	client, err := c.getClientsWithFilters(false, "")
-	if err != nil {
-		return nil, err
-	}
-
-	return client, nil
-}
-
-// getClientsWithFilters fetches active clients. It tries the OpenAPI v2 endpoint
-// first (POST with JSON body, used by the web UI), then falls back to the legacy
-// api/v2 GET endpoint, and finally to the insight endpoint.
-func (c *Client) getClientsWithFilters(filtersEnabled bool, mac string) ([]NetworkClient, error) {
 	// Try OpenAPI v2 endpoint (works for all clients on v6.x, same as web UI)
-	clients, err := c.getClientsOpenAPI(filtersEnabled, mac)
+	clients, err := c.getClientsOpenAPI()
 	if err == nil {
 		return clients, nil
 	}
 	log.Debug().Err(err).Msg("OpenAPI clients endpoint failed, trying legacy endpoint")
 
 	// Fallback: try legacy api/v2 GET endpoint (works on older controllers)
-	clients, err = c.getClientsLegacy(filtersEnabled, mac)
+	clients, err = c.getClientsLegacy()
 	if err == nil {
 		return clients, nil
 	}
@@ -59,29 +35,16 @@ func (c *Client) getClientsWithFilters(filtersEnabled bool, mac string) ([]Netwo
 		return nil, fmt.Errorf("all client endpoints failed: openapi, legacy, insight (%v)", insightErr)
 	}
 
-	if filtersEnabled && mac != "" {
-		var filtered []NetworkClient
-		for _, cl := range clients {
-			if cl.SwitchMac == mac {
-				filtered = append(filtered, cl)
-			}
-		}
-		return filtered, nil
-	}
-
 	return clients, nil
 }
 
 // getClientsOpenAPI fetches clients via the OpenAPI v2 POST endpoint.
 // This is the same endpoint the Omada web UI uses and returns full data
 // for both wired and wireless clients, even with Viewer role on v6.x.
-func (c *Client) getClientsOpenAPI(filtersEnabled bool, mac string) ([]NetworkClient, error) {
+func (c *Client) getClientsOpenAPI() ([]NetworkClient, error) {
 	url := fmt.Sprintf("%s/openapi/v2/%s/sites/%s/clients", c.Config.Host, c.omadaCID, c.SiteId)
 
 	filters := map[string]interface{}{"active": true}
-	if filtersEnabled && mac != "" {
-		filters["switchMac"] = mac
-	}
 
 	reqBody := map[string]interface{}{
 		"filters":  filters,
@@ -125,7 +88,7 @@ func (c *Client) getClientsOpenAPI(filtersEnabled bool, mac string) ([]NetworkCl
 
 // getClientsLegacy fetches clients via the legacy api/v2 GET endpoint.
 // This works on older Omada controllers but may fail on v6.x for Viewer role.
-func (c *Client) getClientsLegacy(filtersEnabled bool, mac string) ([]NetworkClient, error) {
+func (c *Client) getClientsLegacy() ([]NetworkClient, error) {
 	url := fmt.Sprintf("%s/%s/api/v2/sites/%s/clients", c.Config.Host, c.omadaCID, c.SiteId)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -136,9 +99,6 @@ func (c *Client) getClientsLegacy(filtersEnabled bool, mac string) ([]NetworkCli
 	q.Add("currentPage", "1")
 	q.Add("currentPageSize", "10000")
 	q.Add("filters.active", "true")
-	if filtersEnabled {
-		q.Add("filters.switchMac", mac)
-	}
 
 	req.URL.RawQuery = q.Encode()
 
@@ -233,77 +193,6 @@ func (c *Client) getClientsFromInsight() ([]NetworkClient, error) {
 		Msg("Using insight/clients fallback (some metrics unavailable)")
 
 	return clients, nil
-}
-
-// getWiredClientsDetailed fetches wired client MACs from insight, then gets
-// full details for each via /clients/{mac} (which works for Viewer role on v6.x).
-func (c *Client) getWiredClientsFromInsight() ([]NetworkClient, error) {
-	insightClients, err := c.getClientsFromInsight()
-	if err != nil {
-		return nil, err
-	}
-
-	var wiredMacs []string
-	for _, cl := range insightClients {
-		if !cl.Wireless {
-			wiredMacs = append(wiredMacs, cl.Mac)
-		}
-	}
-
-	if len(wiredMacs) == 0 {
-		return nil, nil
-	}
-
-	// Fetch full details for each wired client via /clients/{mac}
-	var wired []NetworkClient
-	for _, mac := range wiredMacs {
-		client, err := c.getClientByMac(mac)
-		if err != nil {
-			log.Debug().Err(err).Str("mac", mac).Msg("Failed to fetch wired client detail")
-			continue
-		}
-		if client != nil {
-			wired = append(wired, *client)
-		}
-	}
-
-	log.Info().Int("wired", len(wired)).Int("macs", len(wiredMacs)).
-		Msg("Fetched wired client details via per-client endpoint")
-
-	return wired, nil
-}
-
-// getClientByMac fetches full details for a single client by MAC address.
-// This endpoint works for Viewer role on v6.x even when the list endpoint doesn't.
-func (c *Client) getClientByMac(mac string) (*NetworkClient, error) {
-	url := fmt.Sprintf("%s/%s/api/v2/sites/%s/clients/%s", c.Config.Host, c.omadaCID, c.SiteId, mac)
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := c.makeLoggedInRequest(req)
-	if err != nil {
-		return nil, err
-	}
-
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	raw, err := checkResponse(body)
-	if err != nil {
-		return nil, err
-	}
-
-	var client NetworkClient
-	if err := json.Unmarshal(raw, &client); err != nil {
-		return nil, fmt.Errorf("failed to parse client %s: %w", mac, err)
-	}
-
-	return &client, nil
 }
 
 type NetworkClient struct {

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -9,8 +9,9 @@ import (
 	log "github.com/rs/zerolog/log"
 )
 
+
 func (c *Client) GetController() (*Controller, error) {
-	url := fmt.Sprintf("%s/%s/api/v2/maintenance/controllerStatus?", c.Config.Host, c.omadaCID)
+	url := fmt.Sprintf("%s/%s/api/v2/maintenance/controllerStatus", c.Config.Host, c.omadaCID)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -28,14 +29,18 @@ func (c *Client) GetController() (*Controller, error) {
 	}
 	log.Debug().Bytes("data", body).Msg("Received data from controllerStatus endpoint")
 
-	controllerData := controllerResponse{}
-	err = json.Unmarshal(body, &controllerData)
+	raw, err := checkResponse(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get controller status: %w", err)
+	}
 
-	return &controllerData.Result, err
-}
+	var controller Controller
+	err = json.Unmarshal(raw, &controller)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse controller status: %w", err)
+	}
 
-type controllerResponse struct {
-	Result Controller `json:"result"`
+	return &controller, nil
 }
 type Controller struct {
 	Name              string       `json:"name"`

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	log "github.com/rs/zerolog/log"
+)
+
+func (c *Client) GetSiteOverview() (*SiteOverview, error) {
+	url := fmt.Sprintf("%s/%s/api/v2/sites/%s/dashboard/overviewDiagram", c.Config.Host, c.omadaCID, c.SiteId)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.makeLoggedInRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	log.Debug().Bytes("data", body).Msg("Received data from overviewDiagram endpoint")
+
+	raw, err := checkResponse(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get site overview: %w", err)
+	}
+
+	var overview SiteOverview
+	err = json.Unmarshal(raw, &overview)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse site overview: %w", err)
+	}
+
+	return &overview, nil
+}
+
+type SiteOverview struct {
+	TotalApNum          float64 `json:"totalApNum"`
+	ConnectedApNum      float64 `json:"connectedApNum"`
+	DisconnectedApNum   float64 `json:"disconnectedApNum"`
+	IsolatedApNum       float64 `json:"isolatedApNum"`
+	TotalSwitchNum      float64 `json:"totalSwitchNum"`
+	ConnectedSwitchNum  float64 `json:"connectedSwitchNum"`
+	DisconnectedSwitchNum float64 `json:"disconnectedSwitchNum"`
+	TotalGatewayNum     float64 `json:"totalGatewayNum"`
+	ConnectedGatewayNum float64 `json:"connectedGatewayNum"`
+	DisconnectedGatewayNum float64 `json:"disconnectedGatewayNum"`
+	TotalPorts          float64 `json:"totalPorts"`
+	AvailablePorts      float64 `json:"availablePorts"`
+	PowerConsumption    float64 `json:"powerConsumption"`
+	TotalClientNum      float64 `json:"totalClientNum"`
+	WiredClientNum      float64 `json:"wiredClientNum"`
+	WirelessClientNum   float64 `json:"wirelessClientNum"`
+	GuestNum            float64 `json:"guestNum"`
+}

--- a/pkg/api/device.go
+++ b/pkg/api/device.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -28,25 +27,24 @@ func (c *Client) GetDevices() ([]Device, error) {
 	}
 	log.Debug().Bytes("data", body).Msg("Received data from devices endpoint")
 
-	devicedata := deviceResponse{}
-	err = json.Unmarshal(body, &devicedata)
+	devices, err := parseListResult[Device](body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse devices: %w", err)
+	}
 
-	for i, d := range devicedata.Result {
+	for i, d := range devices {
 		if d.Type == "switch" {
 			switchPorts, err := c.GetPorts(d.Mac)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get ports: %s", err)
 			}
-			devicedata.Result[i].Ports = switchPorts
+			devices[i].Ports = switchPorts
 		}
 	}
 
-	return devicedata.Result, err
+	return devices, nil
 }
 
-type deviceResponse struct {
-	Result []Device `json:"result"`
-}
 type Device struct {
 	Name        string  `json:"name"`
 	Type        string  `json:"type"`

--- a/pkg/api/device.go
+++ b/pkg/api/device.go
@@ -32,16 +32,6 @@ func (c *Client) GetDevices() ([]Device, error) {
 		return nil, fmt.Errorf("failed to parse devices: %w", err)
 	}
 
-	for i, d := range devices {
-		if d.Type == "switch" {
-			switchPorts, err := c.GetPorts(d.Mac)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get ports: %s", err)
-			}
-			devices[i].Ports = switchPorts
-		}
-	}
-
 	return devices, nil
 }
 

--- a/pkg/api/port.go
+++ b/pkg/api/port.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -28,15 +27,14 @@ func (c *Client) GetPorts(switchMac string) ([]Port, error) {
 	}
 	log.Debug().Bytes("data", body).Msg("Received data from ports endpoint")
 
-	portdata := portResponse{}
-	err = json.Unmarshal(body, &portdata)
+	ports, err := parseListResult[Port](body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ports: %w", err)
+	}
 
-	return portdata.Result, err
+	return ports, nil
 }
 
-type portResponse struct {
-	Result []Port `json:"result"`
-}
 type Port struct {
 	Id          string     `json:"id"`
 	SwitchId    string     `json:"switchId"`

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -5,11 +5,31 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
+	log "github.com/rs/zerolog/log"
 )
 
-// there's no nice way of fetching the site ID from the `Viewer` role
-// calling the user endpoint seems to return a list of sites for the user
+// getSiteId resolves a site name to its internal ID.
+// It tries the user privileges endpoint first, then falls back to the sites
+// listing endpoint for users with allSite privileges or different API versions.
 func (c *Client) getSiteId(name string) (*string, error) {
+	// Try user privileges endpoint first
+	sid, err := c.getSiteIdFromUser(name)
+	if err == nil {
+		return sid, nil
+	}
+	log.Debug().Err(err).Msg("Failed to get site ID from user endpoint, trying sites list")
+
+	// Fallback: list all sites
+	sid, err = c.getSiteIdFromSitesList(name)
+	if err == nil {
+		return sid, nil
+	}
+
+	return nil, fmt.Errorf("failed to find site with name %q: tried user privileges and sites list endpoints", name)
+}
+
+func (c *Client) getSiteIdFromUser(name string) (*string, error) {
 	url := fmt.Sprintf("%s/%s/api/v2/users/current", c.Config.Host, c.omadaCID)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -27,23 +47,98 @@ func (c *Client) getSiteId(name string) (*string, error) {
 		return nil, err
 	}
 
-	user := userResponse{}
-	err = json.Unmarshal(body, &user)
+	raw, err := checkResponse(body)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, s := range user.Result.Privilege.Sites {
+	user := user{}
+	err = json.Unmarshal(raw, &user)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, s := range user.Privilege.Sites {
 		if s.Key == name {
 			return &s.Value, nil
 		}
 	}
 
-	return nil, fmt.Errorf("failed to find site with name %s", name)
+	return nil, fmt.Errorf("site %q not found in user privileges (%d sites listed)", name, len(user.Privilege.Sites))
 }
 
-type userResponse struct {
-	Result user `json:"result"`
+// getSiteIdFromSitesList fetches the site ID from the sites listing endpoint.
+// This works for admin users and newer Omada controller versions where
+// the user privileges endpoint may not include the site list.
+func (c *Client) getSiteIdFromSitesList(name string) (*string, error) {
+	url := fmt.Sprintf("%s/%s/api/v2/sites", c.Config.Host, c.omadaCID)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	q := req.URL.Query()
+	q.Add("currentPage", "1")
+	q.Add("currentPageSize", "1000")
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := c.makeLoggedInRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := checkResponse(body)
+	if err != nil {
+		return nil, err
+	}
+
+	// The sites endpoint may return paginated or direct results
+	type siteEntry struct {
+		Name   string `json:"name"`
+		SiteId string `json:"id"`
+		Key    string `json:"key"`
+	}
+
+	// Try paginated format
+	var paginated struct {
+		Data []siteEntry `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &paginated); err == nil && paginated.Data != nil {
+		for _, s := range paginated.Data {
+			if s.Name == name {
+				id := s.SiteId
+				if id == "" {
+					id = s.Key
+				}
+				return &id, nil
+			}
+		}
+		return nil, fmt.Errorf("site %q not found in sites list (%d sites)", name, len(paginated.Data))
+	}
+
+	// Try direct array format
+	var sites []siteEntry
+	if err := json.Unmarshal(raw, &sites); err != nil {
+		return nil, fmt.Errorf("failed to parse sites list: %w", err)
+	}
+
+	for _, s := range sites {
+		if s.Name == name {
+			id := s.SiteId
+			if id == "" {
+				id = s.Key
+			}
+			return &id, nil
+		}
+	}
+
+	return nil, fmt.Errorf("site %q not found in sites list (%d sites)", name, len(sites))
 }
 
 type user struct {
@@ -51,7 +146,8 @@ type user struct {
 }
 
 type privilege struct {
-	Sites []site `json:"sites"`
+	AllSite bool   `json:"allSite"`
+	Sites   []site `json:"sites"`
 }
 
 type site struct {

--- a/pkg/collector/client.go
+++ b/pkg/collector/client.go
@@ -71,25 +71,37 @@ func (c *clientCollector) Collect(ch chan<- prometheus.Metric) {
 		if item.Wireless {
 			wifiMode := FormatWifiMode(int(item.WifiMode))
 
-			CollectWirelessMetrics := func(desc *prometheus.Desc, valueType prometheus.ValueType, value float64) {
+			collectWirelessOnly := func(desc *prometheus.Desc, valueType prometheus.ValueType, value float64) {
 				ch <- prometheus.MustNewConstMetric(desc, valueType, value,
 					item.Name, item.Vendor, item.Ip, item.Mac, item.HostName, site, client.SiteId, "wireless", wifiMode, item.ApName, item.Ssid, vlanId)
 			}
-			CollectWirelessMetrics(c.omadaClientSignalPct, prometheus.GaugeValue, item.SignalLevel)
-			CollectWirelessMetrics(c.omadaClientSignalNoiseDbm, prometheus.GaugeValue, item.SignalNoise)
-			CollectWirelessMetrics(c.omadaClientRssiDbm, prometheus.GaugeValue, item.Rssi)
-			CollectWirelessMetrics(c.omadaClientTrafficDown, prometheus.CounterValue, item.TrafficDown)
-			CollectWirelessMetrics(c.omadaClientTrafficUp, prometheus.CounterValue, item.TrafficUp)
-			CollectWirelessMetrics(c.omadaClientTxRate, prometheus.GaugeValue, item.TxRate)
-			CollectWirelessMetrics(c.omadaClientRxRate, prometheus.GaugeValue, item.RxRate)
+			collectWirelessOnly(c.omadaClientSignalPct, prometheus.GaugeValue, item.SignalLevel)
+			collectWirelessOnly(c.omadaClientSignalNoiseDbm, prometheus.GaugeValue, item.SignalNoise)
+			collectWirelessOnly(c.omadaClientRssiDbm, prometheus.GaugeValue, item.Rssi)
 
 			totals[wifiMode] += 1
 			ch <- prometheus.MustNewConstMetric(c.omadaClientDownloadActivityBytes, prometheus.GaugeValue, item.Activity,
+				item.Name, item.Vendor, item.Ip, item.Mac, item.HostName, site, client.SiteId, "wireless", wifiMode, item.ApName, item.Ssid, vlanId, "")
+			ch <- prometheus.MustNewConstMetric(c.omadaClientTrafficDown, prometheus.CounterValue, item.TrafficDown,
+				item.Name, item.Vendor, item.Ip, item.Mac, item.HostName, site, client.SiteId, "wireless", wifiMode, item.ApName, item.Ssid, vlanId, "")
+			ch <- prometheus.MustNewConstMetric(c.omadaClientTrafficUp, prometheus.CounterValue, item.TrafficUp,
+				item.Name, item.Vendor, item.Ip, item.Mac, item.HostName, site, client.SiteId, "wireless", wifiMode, item.ApName, item.Ssid, vlanId, "")
+			ch <- prometheus.MustNewConstMetric(c.omadaClientTxRate, prometheus.GaugeValue, item.TxRate,
+				item.Name, item.Vendor, item.Ip, item.Mac, item.HostName, site, client.SiteId, "wireless", wifiMode, item.ApName, item.Ssid, vlanId, "")
+			ch <- prometheus.MustNewConstMetric(c.omadaClientRxRate, prometheus.GaugeValue, item.RxRate,
 				item.Name, item.Vendor, item.Ip, item.Mac, item.HostName, site, client.SiteId, "wireless", wifiMode, item.ApName, item.Ssid, vlanId, "")
 		}
 		if !item.Wireless {
 			totals["wired"] += 1
 			ch <- prometheus.MustNewConstMetric(c.omadaClientDownloadActivityBytes, prometheus.GaugeValue, item.Activity,
+				item.Name, item.Vendor, item.Ip, item.Mac, item.HostName, site, client.SiteId, "wired", "", "", "", vlanId, port)
+			ch <- prometheus.MustNewConstMetric(c.omadaClientTrafficDown, prometheus.CounterValue, item.TrafficDown,
+				item.Name, item.Vendor, item.Ip, item.Mac, item.HostName, site, client.SiteId, "wired", "", "", "", vlanId, port)
+			ch <- prometheus.MustNewConstMetric(c.omadaClientTrafficUp, prometheus.CounterValue, item.TrafficUp,
+				item.Name, item.Vendor, item.Ip, item.Mac, item.HostName, site, client.SiteId, "wired", "", "", "", vlanId, port)
+			ch <- prometheus.MustNewConstMetric(c.omadaClientTxRate, prometheus.GaugeValue, item.TxRate,
+				item.Name, item.Vendor, item.Ip, item.Mac, item.HostName, site, client.SiteId, "wired", "", "", "", vlanId, port)
+			ch <- prometheus.MustNewConstMetric(c.omadaClientRxRate, prometheus.GaugeValue, item.RxRate,
 				item.Name, item.Vendor, item.Ip, item.Mac, item.HostName, site, client.SiteId, "wired", "", "", "", vlanId, port)
 		}
 	}
@@ -135,26 +147,26 @@ func NewClientCollector(c *api.Client) *clientCollector {
 		),
 
 		omadaClientTrafficDown: prometheus.NewDesc("omada_client_traffic_down_bytes",
-			"Total bytes received by wireless client.",
-			client_labels,
+			"Total bytes received by the client.",
+			wired_client_labels,
 			nil,
 		),
 
 		omadaClientTrafficUp: prometheus.NewDesc("omada_client_traffic_up_bytes",
-			"Total bytes sent by wireless client.",
-			client_labels,
+			"Total bytes sent by the client.",
+			wired_client_labels,
 			nil,
 		),
 
 		omadaClientTxRate: prometheus.NewDesc("omada_client_tx_rate",
-			"TX rate of wireless client.",
-			client_labels,
+			"TX rate of the client.",
+			wired_client_labels,
 			nil,
 		),
 
 		omadaClientRxRate: prometheus.NewDesc("omada_client_rx_rate",
-			"RX rate of wireless client.",
-			client_labels,
+			"RX rate of the client.",
+			wired_client_labels,
 			nil,
 		),
 

--- a/pkg/collector/device.go
+++ b/pkg/collector/device.go
@@ -21,7 +21,6 @@ type deviceCollector struct {
 
 func (c *deviceCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.omadaDeviceUptimeSeconds
-	ch <- c.omadaDeviceUptimeSeconds
 	ch <- c.omadaDeviceCpuPercentage
 	ch <- c.omadaDeviceMemPercentage
 	ch <- c.omadaDeviceNeedUpgrade

--- a/pkg/collector/port.go
+++ b/pkg/collector/port.go
@@ -36,27 +36,50 @@ func (c *portCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
+	// Fetch all clients once and build a lookup map by (switchMac, port)
+	// This replaces N per-port API calls with a single call.
+	type portKey struct {
+		SwitchMac string
+		Port      float64
+	}
+	clientByPort := map[portKey]*api.NetworkClient{}
+	allClients, err := client.GetClients()
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get clients for port mapping")
+	} else {
+		for i, cl := range allClients {
+			if cl.SwitchMac != "" {
+				clientByPort[portKey{cl.SwitchMac, cl.Port}] = &allClients[i]
+			}
+		}
+	}
+
 	for _, device := range devices {
+		if device.Type != "switch" {
+			continue
+		}
+
+		switchPorts, err := client.GetPorts(device.Mac)
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to get ports")
+			continue
+		}
+
 		// The Omada exporter sometimes returns duplicate ports. e.g an 8 port switch will return 16 ports with identical ports
 		// this causes issues with Prometheus as it tries to register duplicate metrics. A bit of hacky fix, but here we remove
 		// duplicate ports to prevent this error.
-		ports := removeDuplicates(device.Ports)
+		ports := removeDuplicates(switchPorts)
 		for _, p := range ports {
 			var cHostName, cVendor, cVlanID string
 			linkSpeed := getPortByLinkSpeed(p.PortStatus.LinkSpeed)
 
-			portClient, err := client.GetClientByPort(device.Mac, p.Port)
-			if err != nil {
-				log.Error().Err(err).Msg("Failed to get client by port")
-			}
-
-			port := fmt.Sprintf("%.0f", p.Port)
-			if portClient != nil {
+			if portClient, ok := clientByPort[portKey{device.Mac, p.Port}]; ok {
 				cHostName = portClient.HostName
 				cVendor = portClient.Vendor
 				cVlanID = fmt.Sprintf("%.0f", portClient.VlanId)
 			}
 
+			port := fmt.Sprintf("%.0f", p.Port)
 			labels := []string{device.Name, device.Mac, cHostName, cVendor, port, p.Name, p.SwitchMac, p.SwitchId, cVlanID, p.ProfileName, site, client.SiteId}
 
 			ch <- prometheus.MustNewConstMetric(c.omadaPortPowerWatts, prometheus.GaugeValue, p.PortStatus.PoePower, labels...)

--- a/pkg/collector/site.go
+++ b/pkg/collector/site.go
@@ -1,0 +1,102 @@
+package collector
+
+import (
+	"github.com/charlie-haley/omada_exporter/pkg/api"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/rs/zerolog/log"
+)
+
+type siteCollector struct {
+	omadaSiteConnectedAp          *prometheus.Desc
+	omadaSiteDisconnectedAp       *prometheus.Desc
+	omadaSiteIsolatedAp           *prometheus.Desc
+	omadaSiteConnectedSwitch      *prometheus.Desc
+	omadaSiteDisconnectedSwitch   *prometheus.Desc
+	omadaSiteConnectedGateway     *prometheus.Desc
+	omadaSiteDisconnectedGateway  *prometheus.Desc
+	omadaSiteTotalPorts           *prometheus.Desc
+	omadaSiteAvailablePorts       *prometheus.Desc
+	omadaSitePowerConsumptionWatts *prometheus.Desc
+	omadaSiteWiredClients         *prometheus.Desc
+	omadaSiteWirelessClients      *prometheus.Desc
+	omadaSiteGuestClients         *prometheus.Desc
+	client                        *api.Client
+}
+
+func (c *siteCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.omadaSiteConnectedAp
+	ch <- c.omadaSiteDisconnectedAp
+	ch <- c.omadaSiteIsolatedAp
+	ch <- c.omadaSiteConnectedSwitch
+	ch <- c.omadaSiteDisconnectedSwitch
+	ch <- c.omadaSiteConnectedGateway
+	ch <- c.omadaSiteDisconnectedGateway
+	ch <- c.omadaSiteTotalPorts
+	ch <- c.omadaSiteAvailablePorts
+	ch <- c.omadaSitePowerConsumptionWatts
+	ch <- c.omadaSiteWiredClients
+	ch <- c.omadaSiteWirelessClients
+	ch <- c.omadaSiteGuestClients
+}
+
+func (c *siteCollector) Collect(ch chan<- prometheus.Metric) {
+	client := c.client
+	config := c.client.Config
+
+	site := config.Site
+	overview, err := client.GetSiteOverview()
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get site overview")
+		return
+	}
+
+	labels := []string{site, client.SiteId}
+
+	ch <- prometheus.MustNewConstMetric(c.omadaSiteConnectedAp, prometheus.GaugeValue, overview.ConnectedApNum, labels...)
+	ch <- prometheus.MustNewConstMetric(c.omadaSiteDisconnectedAp, prometheus.GaugeValue, overview.DisconnectedApNum, labels...)
+	ch <- prometheus.MustNewConstMetric(c.omadaSiteIsolatedAp, prometheus.GaugeValue, overview.IsolatedApNum, labels...)
+	ch <- prometheus.MustNewConstMetric(c.omadaSiteConnectedSwitch, prometheus.GaugeValue, overview.ConnectedSwitchNum, labels...)
+	ch <- prometheus.MustNewConstMetric(c.omadaSiteDisconnectedSwitch, prometheus.GaugeValue, overview.DisconnectedSwitchNum, labels...)
+	ch <- prometheus.MustNewConstMetric(c.omadaSiteConnectedGateway, prometheus.GaugeValue, overview.ConnectedGatewayNum, labels...)
+	ch <- prometheus.MustNewConstMetric(c.omadaSiteDisconnectedGateway, prometheus.GaugeValue, overview.DisconnectedGatewayNum, labels...)
+	ch <- prometheus.MustNewConstMetric(c.omadaSiteTotalPorts, prometheus.GaugeValue, overview.TotalPorts, labels...)
+	ch <- prometheus.MustNewConstMetric(c.omadaSiteAvailablePorts, prometheus.GaugeValue, overview.AvailablePorts, labels...)
+	ch <- prometheus.MustNewConstMetric(c.omadaSitePowerConsumptionWatts, prometheus.GaugeValue, overview.PowerConsumption, labels...)
+	ch <- prometheus.MustNewConstMetric(c.omadaSiteWiredClients, prometheus.GaugeValue, overview.WiredClientNum, labels...)
+	ch <- prometheus.MustNewConstMetric(c.omadaSiteWirelessClients, prometheus.GaugeValue, overview.WirelessClientNum, labels...)
+	ch <- prometheus.MustNewConstMetric(c.omadaSiteGuestClients, prometheus.GaugeValue, overview.GuestNum, labels...)
+}
+
+func NewSiteCollector(c *api.Client) *siteCollector {
+	labels := []string{"site", "site_id"}
+
+	return &siteCollector{
+		omadaSiteConnectedAp: prometheus.NewDesc("omada_site_connected_ap_num",
+			"Number of connected access points.", labels, nil),
+		omadaSiteDisconnectedAp: prometheus.NewDesc("omada_site_disconnected_ap_num",
+			"Number of disconnected access points.", labels, nil),
+		omadaSiteIsolatedAp: prometheus.NewDesc("omada_site_isolated_ap_num",
+			"Number of isolated access points.", labels, nil),
+		omadaSiteConnectedSwitch: prometheus.NewDesc("omada_site_connected_switch_num",
+			"Number of connected switches.", labels, nil),
+		omadaSiteDisconnectedSwitch: prometheus.NewDesc("omada_site_disconnected_switch_num",
+			"Number of disconnected switches.", labels, nil),
+		omadaSiteConnectedGateway: prometheus.NewDesc("omada_site_connected_gateway_num",
+			"Number of connected gateways.", labels, nil),
+		omadaSiteDisconnectedGateway: prometheus.NewDesc("omada_site_disconnected_gateway_num",
+			"Number of disconnected gateways.", labels, nil),
+		omadaSiteTotalPorts: prometheus.NewDesc("omada_site_total_ports",
+			"Total number of switch ports.", labels, nil),
+		omadaSiteAvailablePorts: prometheus.NewDesc("omada_site_available_ports",
+			"Number of available (unused) switch ports.", labels, nil),
+		omadaSitePowerConsumptionWatts: prometheus.NewDesc("omada_site_power_consumption_watts",
+			"Total PoE power consumption in watts.", labels, nil),
+		omadaSiteWiredClients: prometheus.NewDesc("omada_site_wired_clients",
+			"Number of connected wired clients.", labels, nil),
+		omadaSiteWirelessClients: prometheus.NewDesc("omada_site_wireless_clients",
+			"Number of connected wireless clients.", labels, nil),
+		omadaSiteGuestClients: prometheus.NewDesc("omada_site_guest_clients",
+			"Number of connected guest clients.", labels, nil),
+		client: c,
+	}
+}


### PR DESCRIPTION
- Fix paginated API responses for devices, ports, clients (v6.x wraps lists in {result: {data: [...]}})
- Handle additional auth error codes (-1201, -30109, -40011, -40012)
- Add API error code checking to all endpoints (was silently returning empty data)
- Add site ID fallback via /api/v2/sites endpoint
- Add client endpoint fallback to /insight/clients for Viewer role on v6.x controllers
- Fix filters.switchMac= stray equals in query param

New features:
- Wired client traffic metrics (traffic_down/up, tx/rx rate)
- Site overview metrics from dashboard/overviewDiagram (power consumption, device counts, client breakdown - 13 new metrics)
- Per-collector endpoints (/metrics/client, /metrics/device, etc.)
- Multi-stage Dockerfile for building from source